### PR TITLE
Fix logic in square object for finding valid flippable squares.

### DIFF
--- a/lib/square.js
+++ b/lib/square.js
@@ -98,18 +98,34 @@ Square.prototype.getNeighbors = function() {
 
     // Top
 
-    if(key <= rows) {
+    if (key <= rows) {
         neighbors[1] = null;
         neighbors[0] = null;
         neighbors[7] = null;
+        if (key === 0) {
+            neighbors[6] = null;
+            neighbors[5] = null;
+        }
+        if (key === 7) {
+            neighbors[2] = null;
+            neighbors[3] = null;
+        }
     }
 
     // Bottom
 
-    if(key >= ((rows * rows) - rows)) {
+    if (key >= ((rows * rows) - rows)) {
         neighbors[5] = null;
         neighbors[4] = null;
         neighbors[3] = null;
+        if (key === 56) {
+            neighbors[6] = null;
+            neighbors[7] = null;
+        }
+        if (key === 63) {
+            neighbors[2] = null;
+            neighbors[1] = null;
+        }
     }
 
     // Left


### PR DESCRIPTION
Added extra null square neighbors for the corners. The 0, 7, 56, and 63 indexes have extra squares that need to be accounted for when looking at what squares are affected by a placement. I added the left and upper left to 0, right and upper right to 7, etc. Should fix it. I played it three times and couldn't see any problems.
